### PR TITLE
fix go build missing param

### DIFF
--- a/02-write-your-first-program/README.md
+++ b/02-write-your-first-program/README.md
@@ -27,7 +27,7 @@ Enjoy!
 * **Build a Go program:**
 
     * While inside a program directory, type:
-        * `go build`
+        * `go build main.go`
 
 * **Run a Go program:**
 


### PR DESCRIPTION
the command "go build" is missing a param，run it may cause:
```
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
```