### PR TITLE
Fix: empty output

### DIFF
--- a/16-slices/exercises/15-slicing-housing-prices/solution/main.go
+++ b/16-slices/exercises/15-slicing-housing-prices/solution/main.go
@@ -46,8 +46,8 @@ Istanbul,500,10,5,1000000`
 		}
 	}
 
-	// from cannot be greater than to: reset invalid arg to 0
-	if from > to {
+	// "from" cannot be greater than or equal to "to": reset invalid arg to 0
+	if from >= to {
 		from = 0
 	}
 


### PR DESCRIPTION
Running with the certain arguments cause an issue to return an empty output.

To reproduce the issue run as:

```
go run main.go Size Location
go run main.go Beds Size
go run main.go Baths Beds
go run main.go Price Baths
```

The issue is when we check for "from" and "to" values, we miss a case in which they are equal. As expected, slice[i:i] will return an empty output. If they're equal, "from" should be 0.
