### PR TITLE
Fixing bug on 'very minor' input

### DIFF
--- a/12-switch/exercises/02-richter-scale-2/solution/main.go
+++ b/12-switch/exercises/02-richter-scale-2/solution/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	args := os.Args
-	if len(args) != 2 {
+	if len(args) != 2 && len(args) != 3 {
 		fmt.Println("Tell me the magnitude of the earthquake in human terms.")
 		return
 	}
@@ -27,8 +27,6 @@ func main() {
 	switch desc {
 	case "micro":
 		richter = "less than 2.0"
-	case "very minor":
-		richter = "2 - 2.9"
 	case "minor":
 		richter = "3 - 3.9"
 	case "light":
@@ -45,6 +43,15 @@ func main() {
 		richter = "10+"
 	default:
 		richter = "unknown"
+	}
+
+	/*
+		Since os.Args[1] will get only 'very' string, we need to
+		concatenate os.Args[1] and os.Args[2] to form 'very minor'
+	*/
+	if len(args) == 3 && args[1]+" "+args[2] == "very minor" {
+		richter = "2 - 2.9"
+		desc = args[1] + " " + args[2]
 	}
 
 	fmt.Printf(


### PR DESCRIPTION
When running the program with the "very minor" richter scale, it wouldn't fall into the "very minor" case since it only compared with os.Args[1] when in fact we need to concatenate os.Args[1] and os.Args[2] to retrieve the "very minor" command. This commit fixes this error by adding an additional if clause to check for this case.