### PR TITLE
Fix expected slice example in Chapter 16 Exercise 25

### DIFF
--- a/16-slices/exercises/25-add-lines/main.go
+++ b/16-slices/exercises/25-add-lines/main.go
@@ -31,7 +31,7 @@ import (
 //
 // EXPECTED SLICE (NEW):
 //
-//   [yesterday all my troubles seemed so far \n away now it looks as though they are here to stay \n oh I believe in yesterday \n]
+//   [yesterday all my troubles seemed so far away \n now it looks as though they are here to stay \n oh I believe in yesterday \n]
 //
 //
 // CURRENT OUTPUT


### PR DESCRIPTION
Currently, the example of an expected slice is wrong and doesn't match neither with the expected output a few lines below nor with the output from the solution to the exercise. This is only seen in the comments in the code where the description of the exercise lies, so it's not a bug per se, rather a typo, but it is confusing a little when attempting to understand the problem of the task (at least it confused me when I began the assignment).